### PR TITLE
ngModel and onlySelect results in undefined model

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -2,7 +2,7 @@
 /*global angular, $, setTimeout*/
 
 /*
- *  AngularJS Autocomplete, version 0.5.6
+ *  AngularJS Autocomplete, version 0.5.7
  *  Wrapper for the jQuery UI Autocomplete Widget - v1.10.3
  *  API @ http://api.jqueryui.com/autocomplete/
  *

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-autocomplete",
   "main": "autocomplete.js",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "homepage": "https://github.com/zensh/ui-autocomplete",
   "authors": [
     "Yan Qing <admin@zensh.com>"


### PR DESCRIPTION
Bug fix for you!

indexOf returns -1 for a match, not zero, causing the ngModel to always be empty when onlySelect is true.
