### PR TITLE
Replaced 'onlySelect' option with 'onlySelectValid'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ All the options must be passed through the directive. There have added 5 options
 
 - **html** If true, you can use html string or DOM object in sourceData.label
 - **focusOpen** If true, the suggestion menu auto open with all source data when element focus
-- **onlySelect** If true, element value must be selected from suggestion menu, otherwise the value will be set to ''
+- **onlySelectValid** If true, element value must be selected from suggestion menu, otherwise set validity of 'onlyselect' to false
 - **groupLabel** html string or DOM object, it is used to group suggestion result, it can't be seleted
 - **outHeight** number, it is used to adjust suggestion menu' css style "max-height", and you would set css "overflow-y", see demo.
 
@@ -53,7 +53,7 @@ You can config options like this:
             options: {
                 html: true,
                 focusOpen: true,
-                onlySelect: true,
+                onlySelectValid: true,
                 source: function (request, response) {
                     var data = [
                             "Asp",

--- a/autocomplete.js
+++ b/autocomplete.js
@@ -10,7 +10,7 @@
  *  $scope.myOptions = {
  *      options: {
  *          html: false, // boolean, uiAutocomplete extend, if true, you can use html string or DOM object in data.label for source
- *          onlySelect: false, // boolean, uiAutocomplete extend, if true, element value must be selected from suggestion menu, otherwise set to ''.
+ *          onlySelectValid: false, // boolean, uiAutocomplete extend, if true, element value must be selected from suggestion menu, otherwise set validity of 'onlyselect' to false.
  *          focusOpen: false, // boolean, uiAutocomplete extend, if true, the suggestion menu auto open with all source data when focus
  *          groupLabel: null, // html string or DOM object, uiAutocomplete extend, it is used to group suggestion result, it can't be seleted.
  *          outHeight: 0, // number, uiAutocomplete extend, it is used to adjust suggestion menu' css style "max-height".
@@ -166,13 +166,12 @@ angular.module('ui.autocomplete', [])
             },
             change: function (event, ui) {
               // update view value and Model value
-              var value = valueMethod();
+              var value = valueMethod(),
+                selected = false;
 
-              if (!selectItem || !selectItem.item || (value.indexOf(selectItem.item.value) == -1)) {
-                // if onlySelect, element value must be selected from search menu, otherwise set to ''.
-                value = autocomplete.options.onlySelect ? '' : value;
-              } else {
+              if (selectItem && selectItem.item && (value.indexOf(selectItem.item.value) != -1)) {
                 value = selectItem.item.value;
+                selected = true;
               }
               if (value === null) {
                 ctrl.$render();
@@ -183,6 +182,9 @@ angular.module('ui.autocomplete', [])
               } else if (ctrl.$viewValue !== value) {
                 scope.$apply(function () {
                   ctrl.$setViewValue(value);
+                  if (autocomplete.options.onlySelectValid) {
+                    ctrl.$setValidity('onlyselect', selected);
+                  }
                   ctrl.$render();
                   changeNgModel(selectItem);
                 });

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -102,7 +102,7 @@ controller('uiAutocompleteCtr', ['$scope', '$compile',
             options: {
                 html: true,
                 minLength: 1,
-                onlySelect: true,
+                onlySelectValid: true,
                 outHeight: 50,
                 source: function (request, response) {
                     var data = [
@@ -151,7 +151,7 @@ controller('uiAutocompleteCtr', ['$scope', '$compile',
         $scope.searchGroup = {
             options: {
                 focusOpen: true,
-                onlySelect: true,
+                onlySelectValid: true,
                 source: function (request, response) {
                     var data = [
                         "guest",
@@ -199,7 +199,7 @@ controller('uiAutocompleteCtr', ['$scope', '$compile',
       options: {
             html: true,
             focusOpen: true,
-            onlySelect: true,
+            onlySelectValid: true,
             source: function (request, response) {
                 console.log(123, request, response)
                 var listData = $scope.data[listId];


### PR DESCRIPTION
Reseting of the input's value is not really clear and intuitive behavior.

I'm suggesting to replace 'onlySelect' option with 'onlySelectValid' that will set validity of the custom valid field 'onlyselect'.
In this case you can react to invalid input in all default Angular ways such as displaying error message, etc.

Thnx.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zensh/ui-autocomplete/20)
<!-- Reviewable:end -->
